### PR TITLE
sqlite doesn't like parentheses in column names

### DIFF
--- a/notebooks/teresa_data_cleaning.ipynb
+++ b/notebooks/teresa_data_cleaning.ipynb
@@ -534,17 +534,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
     "# convert column names to better format\n",
-    "npi.columns = [x.lower().replace(' ', '_') for x in npi.columns]"
+    "npi.columns = [x.lower().replace(' ', '_').replace('(', '').replace(')', '') for x in npi.columns]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -603,7 +603,7 @@
        "0   8180697"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Additional massaging of column names for npi file.